### PR TITLE
Array types

### DIFF
--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -20,21 +20,33 @@ describe "Session" do
     end
   end
 
-  describe ".array" do
-    it "can save an array" do
+  describe ".object" do
+    it "can be saved" do
       session = Session.new(create_context(SESSION_ID))
-      session.array("all_the_things", [1, "asdf", 2.0, true])
-      session.array("all_the_things").should eq([1, "asdf", 2.0, true])
+      session.object("obj", User.new(1, "cool"))
+      user = session.object?("obj")
+      user.should_not be_nil
+      if user
+        user = user.as(User)
+        user.id.should eq(1)
+        user.name.should eq("cool")
+
+        user1 = User.unserialize("{ \"id\": 1, \"name\": \"cool\" }")
+        user1.id.should eq(1)
+        user1.name.should eq("cool")
+      end
     end
 
-    it "can save a mutated array" do
+    it "can return nil" do
       session = Session.new(create_context(SESSION_ID))
-      array = [1, 2, 3] of Session::SessionType
-      session.array("all_the_things", array)
-      session.array("all_the_things").should eq(array)
-      array << "awesome"
-      session.array("all_the_things", array)
-      session.array("all_the_things").should eq(array)
+      user = session.object?("obj")
+      user.should be_nil
+    end
+
+    it "will raise error if storable object is missing unserialize" do
+      expect_raises("Session::StorableObject::NotImplementedException") do
+        BadUser.unserialize("wow")
+      end
     end
   end
 

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -20,6 +20,24 @@ describe "Session" do
     end
   end
 
+  describe ".array" do
+    it "can save an array" do
+      session = Session.new(create_context(SESSION_ID))
+      session.array("all_the_things", [1, "asdf", 2.0, true])
+      session.array("all_the_things").should eq([1, "asdf", 2.0, true])
+    end
+
+    it "can save a mutated array" do
+      session = Session.new(create_context(SESSION_ID))
+      array = [1, 2, 3] of Session::SessionType
+      session.array("all_the_things", array)
+      session.array("all_the_things").should eq(array)
+      array << "awesome"
+      session.array("all_the_things", array)
+      session.array("all_the_things").should eq(array)
+    end
+  end
+
   describe ".destroy" do
     it "should delete a session and remove cookie in current session" do
       context = create_context(SESSION_ID)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "json"
 require "../src/kemal-session"
 require "file_utils"
 
@@ -29,4 +30,32 @@ def create_context(session_id : String)
 
   request = HTTP::Request.new("GET", "/", headers)
   return HTTP::Server::Context.new(request, response)
+end
+
+class User < Session::StorableObject
+  JSON.mapping(
+    id: Int32,
+    name: String
+  )
+
+  def initialize(@id : Int32, @name : String)
+  end
+
+  def serialize
+    return self.to_json
+  end
+
+  def self.unserialize(str : String)
+    return self.from_json(str)
+  end
+end
+
+class BadUser < Session::StorableObject
+  property name
+
+  def initialize(@name : String); end
+
+  def serialize
+    return @name
+  end
 end

--- a/src/kemal-session/engine.cr
+++ b/src/kemal-session/engine.cr
@@ -1,4 +1,7 @@
 class Session
+
+  alias SessionType = Int32 | String | Float64 | Bool
+
   macro abstract_engine(vars)
     abstract class Engine
 
@@ -43,6 +46,6 @@ class Session
     {% end %}
   end
 
-  abstract_engine({int: Int32, string: String, float: Float64, bool: Bool})
+  abstract_engine({int: Int32, string: String, float: Float64, bool: Bool, array: Array(SessionType)})
   GC.new
 end

--- a/src/kemal-session/engine.cr
+++ b/src/kemal-session/engine.cr
@@ -1,7 +1,4 @@
 class Session
-
-  alias SessionType = Int32 | String | Float64 | Bool
-
   macro abstract_engine(vars)
     abstract class Engine
 
@@ -46,6 +43,6 @@ class Session
     {% end %}
   end
 
-  abstract_engine({int: Int32, string: String, float: Float64, bool: Bool, array: Array(SessionType)})
+  abstract_engine({int: Int32, string: String, float: Float64, bool: Bool, object: Session::StorableObject})
   GC.new
 end

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -35,7 +35,7 @@ class Session
         end
       end
 
-      define_storage({int: Int32, string: String, float: Float64, bool: Bool})
+      define_storage({int: Int32, string: String, float: Float64, bool: Bool, array: Array(SessionType)})
     end
 
     @store : Hash(String, StorageInstance)
@@ -108,6 +108,6 @@ class Session
       {% end %}
     end
 
-    define_delegators({int: Int32, string: String, float: Float64, bool: Bool})
+    define_delegators({int: Int32, string: String, float: Float64, bool: Bool, array: Array(SessionType)})
   end
 end

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -35,7 +35,7 @@ class Session
         end
       end
 
-      define_storage({int: Int32, string: String, float: Float64, bool: Bool, array: Array(SessionType)})
+      define_storage({int: Int32, string: String, float: Float64, bool: Bool, object: Session::StorableObject})
     end
 
     @store : Hash(String, StorageInstance)
@@ -108,6 +108,6 @@ class Session
       {% end %}
     end
 
-    define_delegators({int: Int32, string: String, float: Float64, bool: Bool, array: Array(SessionType)})
+    define_delegators({int: Int32, string: String, float: Float64, bool: Bool, object: Session::StorableObject})
   end
 end

--- a/src/kemal-session/storable_object.cr
+++ b/src/kemal-session/storable_object.cr
@@ -2,14 +2,9 @@ class Session
   abstract class StorableObject
     abstract def serialize : String
     def self.unserialize(obj : String) : self
-      raise NotImplementedException.new
+      raise NotImplementedException.new("StorableObject #{self} needs to define the 'self.unserialize' method")
     end
 
-    class NotImplementedException < Exception
-      def initialize
-        error_message = "StorableObject is missing unserialize definition"
-        super
-      end
-    end
+    class NotImplementedException < Exception; end
   end
 end

--- a/src/kemal-session/storable_object.cr
+++ b/src/kemal-session/storable_object.cr
@@ -1,0 +1,15 @@
+class Session
+  abstract class StorableObject
+    abstract def serialize : String
+    def self.unserialize(obj : String) : self
+      raise NotImplementedException.new
+    end
+
+    class NotImplementedException < Exception
+      def initialize
+        error_message = "StorableObject is missing unserialize definition"
+        super
+      end
+    end
+  end
+end


### PR DESCRIPTION
The quickest way I could think of adding the ability to do arrays was to define a new `SessionType` alias. When working with the array as part of the session, the developer would have to save the entire array again. The [spec](https://github.com/neovintage/kemal-session/blob/array-type/spec/base_spec.cr#L23-L39) has a more concrete definition of what I'm trying to communicate.

The only wonky thing about this implementation is that if the array being defined outside of the session is all integers, for example, that array needs to be cast as `Session::SessionType`:

```
array = [1, 2, 3] of Session::SessionType
context.session.array("all_the_things", array)
```

The alternative is to define array methods for every permutation of type when the `define_delegators` macros get invoked. I opted for the current implementation because I perceived it to have more flexibility for the developer working with sessions in kemal versus the alternative where an array might mutate with a subset of the session types. For example, if a developer initially creates an array of all ints but, later, defines that array to be Int32 | String.

/cc @Thyra @sdogruyol 