### PR TITLE
removed the affordance for nil from the non-question marked methods

### DIFF
--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -18,6 +18,27 @@ describe "Session" do
       session.int("bar", 12)
       session.int("bar").should eq 12
     end
+
+    it "throws an exception if the key doesnt exist" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_raises(KeyError, /Missing hash key: "something"/) do
+        session.int("something")
+      end
+    end
+  end
+
+  describe ".int?" do
+    it "can return nil" do
+      session = Session.new(create_context(SESSION_ID))
+      val = session.int?("something")
+      val.should be_nil
+    end
+
+    it "can return a value" do
+      session = Session.new(create_context(SESSION_ID))
+      session.int("bar", 12)
+      session.int?("bar").is_a?(Int32).should be_true
+    end
   end
 
   describe ".object" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -42,11 +42,11 @@ class User < Session::StorableObject
   end
 
   def serialize
-    return self.to_json
+    return to_json
   end
 
   def self.unserialize(str : String)
-    return self.from_json(str)
+    return User.from_json(str)
   end
 end
 

--- a/src/kemal-session/engine.cr
+++ b/src/kemal-session/engine.cr
@@ -24,7 +24,7 @@ class Session
     # generate delegators for each type (Session -> Engine)
     {% for name, type in vars %}
 
-      def {{name.id}}(k : String) : {{type}}?
+      def {{name.id}}(k : String) : {{type}}
         Session.config.engine.{{name.id}}(@id, k)
       end
 

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -87,8 +87,8 @@ class Session
     macro define_delegators(vars)
       {% for name, type in vars %}
 
-        def {{name.id}}(session_id : String, k : String) : {{type}}?
-          return @store[session_id]?.try &.{{name.id}}(k)
+        def {{name.id}}(session_id : String, k : String) : {{type}}
+          return @store[session_id].{{name.id}}(k)
         end
 
         def {{name.id}}?(session_id : String, k : String) : {{type}}?


### PR DESCRIPTION
@Thyra @sdogruyol 

I was using kemal-session on a side project and I ran into something that I think might warrant discussion. In the documentation, we don't clearly state what's supposed to happen if you issue a statement like this:

```
context.session.int("user_id")
```

The issue I'm having is that in the original code the return type allowed for the non-question marked methods is the original type or nil. That effectively makes these two calls the same:

```
context.session.int?("user_id") # could return int32 or nil
context.session.int("user_id") # could return int32 or nil
```

The proposal here is that if you issue the method without the question mark (`context.session.int`) and the key does not exist, the program should throw an exception.

Thoughts?

