### PR TITLE
Memory Engine & StorableObjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,29 +63,23 @@ end
 #### StorableObject
 
 `kemal-session` has the ability to save objects to session storage. By saving objects to session storage, this opens up the ability to have more advanced data types that aren't supported by the base types (Int32, Int64, Float64, String, Bool).
-Any object that you want to save to session storage needs to be a subclass of `Session::StorableObject`.
-The subclass needs to define two different methods. First, a class method to deserialize the object from a String, called `unserialize`. The
-second method, is an instance method called `serialize`. `serialize` will take the object and turn it into a String for the session storage engine to
-handle. Here's an example implementation:
+Any object that you want to save to session storage needs to include the `Session::StorableObject` module. The class must respond to `to_json` and `from_json`. **NOTE** The module must be included after the definition of `to_json` and `from_json`.
+Otherwise the compiler will not know that those methods have been defined on the class.
+Here's an example implementation:
 
 ```crystal
-class UserStorableObject < Session::StorableObject
-  property id, name
+class UserStorableObject
+  JSON.mapping({
+    id: Int32,
+    name: String
+  })
+  include Session::StorableObject
 
   def initialize(@id : Int32, @name : String); end
-
-  def serialize
-    return "#{@id};#{@name}"
-  end
-
-  def self.unserialize(value : String)
-    parts = value.split(";")
-    return self.new(parts[0].to_i, parts[1])
-  end
 end
 ```
 
-Once a `StorableObject` subclass has been defined, you can save that in session storage just like the base types. Here's an example using
+Once a `StorableObject` has been defined, you can save that in session storage just like the base types. Here's an example using
 the `UserStorableObject` implementation:
 
 ```crystal
@@ -176,9 +170,6 @@ Additionally, depending on the engine used and on how many active sessions there
 - Garbage collector that removes expired sessions from the server
 - Memory engine
 - Manage sessions: Session.all, Session.remove(id), Session.get(id)
-
-## Roadmap
-- More data types, including arrays and possibly hashes
 
 ## Compatible Engines
 

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -65,10 +65,6 @@ describe "Session" do
         user = user.as(User)
         user.id.should eq(1)
         user.name.should eq("cool")
-
-        user1 = User.unserialize("{ \"id\": 1, \"name\": \"cool\" }")
-        user1.id.should eq(1)
-        user1.name.should eq("cool")
       end
     end
 
@@ -78,11 +74,12 @@ describe "Session" do
       user.should be_nil
     end
 
-    it "will raise error if storable object is missing unserialize" do
-      expect_raises("Session::StorableObject::NotImplementedException") do
-        BadUser.unserialize("wow")
-      end
-    end
+    # TODO reimplement to check compiler errors
+    #it "will raise error if storable object is missing unserialize" do
+      #expect_raises("Session::StorableObject::NotImplementedException") do
+        #BadUser.unserialize("wow")
+      #end
+    #end
   end
 
   describe ".destroy" do

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -74,12 +74,21 @@ describe "Session" do
       user.should be_nil
     end
 
-    # TODO reimplement to check compiler errors
-    #it "will raise error if storable object is missing unserialize" do
-      #expect_raises("Session::StorableObject::NotImplementedException") do
-        #BadUser.unserialize("wow")
-      #end
-    #end
+    it "will be serialized in memory engine" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_raises Exception, "calling to_json" do
+        session.object("obj", UserTestSerialization.new(1_i64))
+      end
+    end
+
+    it "will be deserialized in memory engine" do
+      session = Session.new(create_context(SESSION_ID))
+      session.object("obj", UserTestDeserialization.new(1_i64))
+      s = Session.get(SESSION_ID)
+      expect_raises Exception, "calling from_json" do
+        s.as(Session).object("obj")
+      end
+    end
   end
 
   describe ".destroy" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -46,3 +46,31 @@ class User
   def initialize(@id : Int32, @name : String)
   end
 end
+
+class UserTestSerialization
+  def initialize(@id : Int64); end
+
+  def self.from_json(parser)
+    raise Exception.new("calling from_json")
+  end
+
+  def to_json(io)
+    raise Exception.new("calling to_json")
+  end
+
+  include Session::StorableObject
+end
+
+class UserTestDeserialization
+  def initialize(@id : Int64); end
+
+  def self.from_json(parser)
+    raise Exception.new("calling from_json")
+  end
+
+  def to_json(io)
+    @id.to_s io
+  end
+
+  include Session::StorableObject
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -54,7 +54,7 @@ class UserTestSerialization
     raise Exception.new("calling from_json")
   end
 
-  def to_json(io)
+  def to_json(json)
     raise Exception.new("calling to_json")
   end
 
@@ -68,8 +68,8 @@ class UserTestDeserialization
     raise Exception.new("calling from_json")
   end
 
-  def to_json(io)
-    @id.to_s io
+  def to_json(json : JSON::Builder)
+    json.number(@id)
   end
 
   include Session::StorableObject

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -14,6 +14,10 @@ SESSION_SECRET = "b3c631c314c0bbca50c1b2843150fe33"
 SESSION_ID     = SecureRandom.hex
 SIGNED_SESSION = "#{SESSION_ID}--#{Session.sign_value(SESSION_ID)}"
 
+def create_new_session
+  create_context(SecureRandom.hex)
+end
+
 def create_context(session_id : String)
   response = HTTP::Server::Response.new(IO::Memory.new)
   headers = HTTP::Headers.new
@@ -32,30 +36,13 @@ def create_context(session_id : String)
   return HTTP::Server::Context.new(request, response)
 end
 
-class User < Session::StorableObject
+class User
   JSON.mapping(
     id: Int32,
     name: String
   )
+  include Session::StorableObject
 
   def initialize(@id : Int32, @name : String)
-  end
-
-  def serialize
-    return to_json
-  end
-
-  def self.unserialize(str : String)
-    return User.from_json(str)
-  end
-end
-
-class BadUser < Session::StorableObject
-  property name
-
-  def initialize(@name : String); end
-
-  def serialize
-    return @name
   end
 end

--- a/src/kemal-session.cr
+++ b/src/kemal-session.cr
@@ -2,3 +2,5 @@ require "http"
 require "./kemal-session/*"
 require "./kemal-session/ext/*"
 require "./kemal-session/engines/*"
+
+

--- a/src/kemal-session/engine.cr
+++ b/src/kemal-session/engine.cr
@@ -49,7 +49,7 @@ class Session
     string: String,
     float: Float64,
     bool: Bool,
-    object: Session::StorableObject
+    object: StorableObjects,
   })
   GC.new
 end

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -41,7 +41,7 @@ class Session
         string: String,
         float: Float64,
         bool: Bool,
-        object: Session::StorableObject
+        object: StorableObjects
       })
     end
 
@@ -121,7 +121,7 @@ class Session
       string: String,
       float: Float64,
       bool: Bool,
-      object: Session::StorableObject
+      object: StorableObjects,
     })
   end
 end


### PR DESCRIPTION
**do not merge**

One of the issues I have with memory engine is that the serialization and deserialization of StorableObjects wasn't happening. I was trying to build a library that has the ability to do flash storage (https://github.com/neovintage/kemal-flash) but since those methods weren't being called the flash library wasn't behaving appropriately. 

@sdogruyol @Thyra ==> 
This is a work-in-progress PR but I'm posting this now because I've reached a roadblock with types. My type-foo isn't quite up to snuff yet. It seems when I go to unserialize the StorableObject the abstract class method keeps getting called instead of the one from the subclass. If either of you have ideas on this or the PR in general, let me know.