### PR TITLE
No StorableObjects Defined

### DIFF
--- a/src/kemal-session/storable_object.cr
+++ b/src/kemal-session/storable_object.cr
@@ -17,7 +17,9 @@ class Session
     end
 
     macro finished
-      alias StorableObjects = Union({{ *Session::STORABLE_TYPES }})
+      {% if !Session::STORABLE_TYPES.empty? %}
+        alias StorableObjects = Union({{ *Session::STORABLE_TYPES }})
+      {% end %}
     end
   end
 end

--- a/src/kemal-session/storable_object.cr
+++ b/src/kemal-session/storable_object.cr
@@ -19,6 +19,8 @@ class Session
     macro finished
       {% if !Session::STORABLE_TYPES.empty? %}
         alias StorableObjects = Union({{ *Session::STORABLE_TYPES }})
+      {% else %}
+        alias StorableObjects = Nil
       {% end %}
     end
   end


### PR DESCRIPTION
When a `kemal-session` is loaded into a project and no StorableObjects are defined it, you'll get a compiler error.

Fixes #22 