### PR TITLE
add Session.before_destroy method

### DIFF
--- a/src/kemal-session/base.cr
+++ b/src/kemal-session/base.cr
@@ -51,7 +51,11 @@ class Session
   # Removes a session from storage
   #
   def self.destroy(id : String)
+    before_destroy(id)
     Session.config.engine.destroy_session(id)
+  end
+
+  def self.before_destroy( id : String)
   end
 
   # Invalidates the session by removing it from storage so that its

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -61,9 +61,9 @@ class Session
 
     def run_gc
       before = (Time.now - Session.config.timeout.as(Time::Span)).epoch_ms
-      @store.delete_if do |id, entry|
+      @store.each do |id, entry|
         last_access_at = Int64.from_json(entry, root: "last_access_at")
-        last_access_at < before
+        Session.destroy(id: id) if last_access_at < before
       end
       sleep Session.config.gc_interval
     end


### PR DESCRIPTION
This creates a `Session.before_destroy( id : String)` method that fires immediately prior to a session being destroyed.  

The concept is pretty simple:  when a session is destroyed, you might have some cleanup or database work that needs to be done.

This update also changes MemoryStorage's `run_gc` method to call Session.destroy rather than destroying it directly.