### PR TITLE
Session timeout

### DIFF
--- a/src/kemal-session/base.cr
+++ b/src/kemal-session/base.cr
@@ -51,11 +51,7 @@ class Session
   # Removes a session from storage
   #
   def self.destroy(id : String)
-    before_destroy(id)
     Session.config.engine.destroy_session(id)
-  end
-
-  def self.before_destroy( id : String)
   end
 
   # Invalidates the session by removing it from storage so that its
@@ -68,6 +64,22 @@ class Session
       context.response.cookies[Session.config.cookie_name].value = ""
     end
     Session.destroy(@id)
+  end
+
+  # Captures a block to be called when the session is garbage collected
+  # the block accepts a string, the id of the session being collected,
+  # as a parameter
+  def self.timeout(&block : String ->)
+    @@timeout_block = block
+  end
+
+  # Called when a session has been garbage collected
+  # checks if a @timeout_block has been set, and calls if it it has
+  def self.timeout(id : String)
+    if (callback = @@timeout_block)
+      callback.call id
+    end
+    destroy(id)
   end
 
   # Destroys all of the sessions stored in the storage engine

--- a/src/kemal-session/base.cr
+++ b/src/kemal-session/base.cr
@@ -51,7 +51,11 @@ class Session
   # Removes a session from storage
   #
   def self.destroy(id : String)
+    before_destroy(id)
     Session.config.engine.destroy_session(id)
+  end
+
+  def self.before_destroy( id : String)
   end
 
   # Invalidates the session by removing it from storage so that its

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -62,9 +62,8 @@ class Session
     def run_gc
       before = (Time.now - Session.config.timeout.as(Time::Span)).epoch_ms
       @store.each do |id, entry|
-        last_access_at = Int64.from_json(entry, root: "last_access_at")
-        Session.destroy(id: id) if last_access_at < before
-      end
+      last_access_at = Int64.from_json(entry, root: "last_access_at")
+      Session.timeout(id) if last_access_at < before
       sleep Session.config.gc_interval
     end
 

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -62,8 +62,9 @@ class Session
     def run_gc
       before = (Time.now - Session.config.timeout.as(Time::Span)).epoch_ms
       @store.each do |id, entry|
-      last_access_at = Int64.from_json(entry, root: "last_access_at")
-      Session.timeout(id) if last_access_at < before
+        last_access_at = Int64.from_json(entry, root: "last_access_at")
+        Session.timeout(id) if last_access_at < before
+      end
       sleep Session.config.gc_interval
     end
 

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -61,9 +61,9 @@ class Session
 
     def run_gc
       before = (Time.now - Session.config.timeout.as(Time::Span)).epoch_ms
-      @store.delete_if do |id, entry|
+      @store.each do |id, entry|
         last_access_at = Int64.from_json(entry, root: "last_access_at")
-        last_access_at < before
+        Session.destroy(id: id) if last_access_at < before
       end
       sleep Session.config.gc_interval
     end


### PR DESCRIPTION
I think it's good to have an event fire in the when a session is garbage collected.

With the changes to this branch, you can accomplish this for MemoryEngine, which I updated.  However, each engine that has a `#run_gc` would need to be updated in a similar fashion (it's pretty easy, see MemoryEngine below).

Here's a use-case.  Suppose your website has users provided by a `User` class.  You could be notified when a session is expiring like this:

```crystal
class User

  Session.timeout {|id| self.timeout(id)}

  def self.timeout( id : String)
    # session just expired.  You can still use Session.get(id) 
    # but the session will be destroyed after this method is finished.
  end

end
```


