### PR TITLE
add ability to remove key-value pairs from session storage

### DIFF
--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -27,6 +27,22 @@ describe "Session" do
     end
   end
 
+  describe ".delete_int" do
+    it "can delete the contents of a key" do
+      session = Session.new(create_context(SESSION_ID))
+      session.int("user_id", 123)
+      session.delete_int("user_id")
+      session.int?("user_id").should be_nil
+    end
+
+    it "should succeed if the key does not exist" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_not_raises do
+        session.delete_int("user_id")
+      end
+    end
+  end
+
   describe ".int?" do
     it "can return nil" do
       session = Session.new(create_context(SESSION_ID))
@@ -52,6 +68,22 @@ describe "Session" do
       session.bigint("bigbar", 12_i64)
       session.bigint("bigbar").should eq 12
       session.bigint("bigbar").is_a?(Int64).should be_true
+    end
+  end
+
+  describe ".delete_bigint" do
+    it "can delete the contents of a key" do
+      session = Session.new(create_context(SESSION_ID))
+      session.bigint("user_id", 123_i64)
+      session.delete_bigint("user_id")
+      session.bigint?("user_id").should be_nil
+    end
+
+    it "should succeed if the key does not exist" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_not_raises do
+        session.delete_bigint("user_id")
+      end
     end
   end
 
@@ -87,6 +119,22 @@ describe "Session" do
       s = Session.get(SESSION_ID)
       expect_raises Exception, "calling from_json" do
         s.as(Session).object("obj")
+      end
+    end
+  end
+
+  describe ".delete_object" do
+    it "can delete the contents of a key" do
+      session = Session.new(create_context(SESSION_ID))
+      session.object("obj", User.new(1, "cool"))
+      session.delete_object("obj")
+      session.object?("obj").should be_nil
+    end
+
+    it "should succeed if the key does not exist" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_not_raises do
+        session.delete_bigint("obj")
       end
     end
   end

--- a/spec/file_spec.cr
+++ b/spec/file_spec.cr
@@ -20,6 +20,11 @@ def get_file_session_contents(session_id)
   File.read(File.join(Dir.current, "spec", "assets", "sessions", "#{session_id}.json"))
 end
 
+def should_be_empty_file_session(session_id)
+  get_file_session_contents(session_id).should \
+    eq("{\"ints\":{},\"bigints\":{},\"strings\":{},\"floats\":{},\"bools\":{},\"objects\":{}}")
+end
+
 describe "Session::FileEngine" do
   describe "options" do
     describe ":sessions_dir" do
@@ -52,6 +57,22 @@ describe "Session::FileEngine" do
     end
   end
 
+  describe ".delete_int" do
+    it "can delete a value" do
+      session = Session.new(create_context(SESSION_ID))
+      session.int("bar", 12)
+      session.delete_int("bar")
+      should_be_empty_file_session(SESSION_ID)
+    end
+
+    it "shouldnt raise an error on empty key" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_not_raises do
+        session.delete_int("bar")
+      end
+    end
+  end
+
   describe ".bigint" do
     it "can save a value" do
       session = Session.new(create_context(SESSION_ID))
@@ -65,6 +86,22 @@ describe "Session::FileEngine" do
       session.bigint("bigbar", 12_i64)
       session.bigint("bigbar").should eq 12
       session.bigint("bigbar").is_a?(Int64).should be_true
+    end
+  end
+
+  describe ".delete_bigint" do
+    it "can delete a value" do
+      session = Session.new(create_context(SESSION_ID))
+      session.bigint("bar", 12_i64)
+      session.delete_bigint("bar")
+      should_be_empty_file_session(SESSION_ID)
+    end
+
+    it "shouldnt raise an error on empty key" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_not_raises do
+        session.delete_bigint("bar")
+      end
     end
   end
 
@@ -83,6 +120,22 @@ describe "Session::FileEngine" do
     end
   end
 
+  describe ".delete_bool" do
+    it "can delete a value" do
+      session = Session.new(create_context(SESSION_ID))
+      session.bool("bar", true)
+      session.delete_bool("bar")
+      should_be_empty_file_session(SESSION_ID)
+    end
+
+    it "shouldnt raise an error on empty key" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_not_raises do
+        session.delete_bool("bar")
+      end
+    end
+  end
+
   describe ".float" do
     it "can save a value" do
       session = Session.new(create_context(SESSION_ID))
@@ -95,6 +148,22 @@ describe "Session::FileEngine" do
       session = Session.new(create_context(SESSION_ID))
       session.float("bar", 3.00)
       session.float("bar").should eq 3.00
+    end
+  end
+
+  describe ".delete_float" do
+    it "can delete a value" do
+      session = Session.new(create_context(SESSION_ID))
+      session.float("bar", 3.00)
+      session.delete_float("bar")
+      should_be_empty_file_session(SESSION_ID)
+    end
+
+    it "shouldnt raise an error on empty key" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_not_raises do
+        session.delete_float("bar")
+      end
     end
   end
 
@@ -113,6 +182,22 @@ describe "Session::FileEngine" do
     end
   end
 
+  describe ".delete_string" do
+    it "can delete a value" do
+      session = Session.new(create_context(SESSION_ID))
+      session.string("bar", "blah")
+      session.delete_string("bar")
+      should_be_empty_file_session(SESSION_ID)
+    end
+
+    it "shouldnt raise an error on empty key" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_not_raises do
+        session.delete_string("bar")
+      end
+    end
+  end
+
   describe ".object" do
     it "can be saved and retrieved" do
       session = Session.new(create_context(SESSION_ID))
@@ -127,6 +212,23 @@ describe "Session::FileEngine" do
       new_u = session.object("user").as(User)
       new_u.id.should eq(123)
       new_u.name.should eq("charlie")
+    end
+  end
+
+  describe ".delete_object" do
+    it "can delete a value" do
+      session = Session.new(create_context(SESSION_ID))
+      u = User.new(123, "charlie")
+      session.object("user", u)
+      session.delete_object("user")
+      should_be_empty_file_session(SESSION_ID)
+    end
+
+    it "shouldnt raise an error on empty key" do
+      session = Session.new(create_context(SESSION_ID))
+      expect_not_raises do
+        session.delete_object("user")
+      end
     end
   end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -36,6 +36,17 @@ def create_context(session_id : String)
   return HTTP::Server::Context.new(request, response)
 end
 
+macro expect_not_raises(file = __FILE__, line = __LINE__)
+  %failed = false
+  begin
+    {{yield}}
+  rescue %ex
+    %ex_to_s = %ex.to_s
+    backtrace = %ex.backtrace.map { |f| "  # #{f}" }.join "\n"
+    fail "Expected no exception, got #<#{ %ex.class }: #{ %ex_to_s }> with backtrace:\n#{backtrace}", {{file}}, {{line}}
+  end
+end
+
 class User
   JSON.mapping(
     id: Int32,

--- a/src/kemal-session/engine.cr
+++ b/src/kemal-session/engine.cr
@@ -42,6 +42,10 @@ class Session
         Session.config.engine.{{name.id}}(@id, k, v)
       end
 
+      def delete_{{name.id}}( k : String)
+        Session.config.engine.delete_{{name.id}}(@id, k)
+      end
+
     {% end %}
   end
 

--- a/src/kemal-session/engines/file.cr
+++ b/src/kemal-session/engines/file.cr
@@ -25,6 +25,12 @@ class Session
           def {{name.id}}(k : String, v : {{type}})
             @{{name.id}}s[k] = v
           end
+
+          def delete_{{name.id}}(k : String)
+            if @{{name.id}}s[k]?
+              @{{name.id}}s.delete(k)
+            end
+          end
         {% end %}
 
         def initialize
@@ -173,6 +179,12 @@ class Session
         def {{name.id}}s(session_id : String) : Hash(String, {{type}})
           load_into_cache(session_id) unless is_in_cache?(session_id)
           return @cache.{{name.id}}s
+        end
+
+        def delete_{{name.id}}(session_id : String, k : String)
+          load_into_cache(session_id) unless is_in_cache?(session_id)
+          @cache.delete_{{name.id}}(k)
+          save_cache
         end
       {% end %}
     end

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -34,6 +34,11 @@ class Session
             @last_access_at = Time.new.epoch_ms
             @{{name.id}}s[k] = v
           end
+
+          def delete_{{name.id}}(k : String)
+            @last_access_at = Time.new.epoch_ms
+            @{{name.id}}s.delete(k) if @{{name.id}}s.has_key?(k)
+          end
         {% end %}
 
         def initialize(@id : String)
@@ -130,6 +135,13 @@ class Session
           return {} of String => {{ type }} unless @store[session_id]?
           storage_instance = StorageInstance.from_json(@store[session_id])
           return storage_instance.{{name.id}}s
+        end
+
+        def delete_{{name.id}}(session_id : String, k : String)
+          return nil unless @store[session_id]?
+          storage_instance = StorageInstance.from_json(@store[session_id])
+          storage_instance.delete_{{name.id}}(k)
+          @store[session_id] = storage_instance.to_json
         end
       {% end %}
     end


### PR DESCRIPTION
Need to specify the types but I think that's ok.

Fixes #20 