### PR TITLE
Creates a StorableObjectContainer. 

### DIFF
--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -121,6 +121,15 @@ describe "Session" do
         s.as(Session).object("obj")
       end
     end
+
+    it "can deserialize multiple objects correctly" do
+      session = Session.new(create_context(SESSION_ID))
+      session.object("obj1", First.new(1_i64))
+      session.object("obj2", Second.new(2_i64))
+
+      session.object("obj1").class.should eq(First)
+      session.object("obj2").class.should eq(Second)
+    end
   end
 
   describe ".delete_object" do

--- a/spec/file_spec.cr
+++ b/spec/file_spec.cr
@@ -204,7 +204,7 @@ describe "Session::FileEngine" do
       u = User.new(123, "charlie")
       session.object("user", u)
       get_file_session_contents(SESSION_ID).should \
-        eq("{\"ints\":{},\"bigints\":{},\"strings\":{},\"floats\":{},\"bools\":{},\"objects\":{\"user\":{\"id\":123,\"name\":\"charlie\"}}}")
+        eq("{\"ints\":{},\"bigints\":{},\"strings\":{},\"floats\":{},\"bools\":{},\"objects\":{\"user\":{\"type\":\"User\",\"object\":{\"id\":123,\"name\":\"charlie\"}}}}")
 
       Session.config.engine.as(Session::FileEngine).clear_cache
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -85,3 +85,29 @@ class UserTestDeserialization
 
   include Session::StorableObject
 end
+
+class First
+  JSON.mapping({
+    id: Int64
+  })
+  include Session::StorableObject
+
+  def initialize(@id : Int64); end
+
+  def name
+    "first"
+  end
+end
+
+class Second
+  JSON.mapping({
+    id: Int64
+  })
+  include Session::StorableObject
+
+  def initialize(@id : Int64); end
+
+  def name
+    "second"
+  end
+end

--- a/src/kemal-session/engines/file.cr
+++ b/src/kemal-session/engines/file.cr
@@ -46,7 +46,7 @@ class Session
         string: String,
         float: Float64,
         bool: Bool,
-        object: Session::StorableObject::StorableObjects
+        object: Session::StorableObject::StorableObjectContainer
       })
     end
 
@@ -195,7 +195,7 @@ class Session
       string: String,
       float: Float64,
       bool: Bool,
-      object: Session::StorableObject::StorableObjects,
+      object: Session::StorableObject::StorableObjectContainer,
     })
   end
 end

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -54,7 +54,7 @@ class Session
         string: String,
         float: Float64,
         bool: Bool,
-        object: Session::StorableObject::StorableObjects
+        object: Session::StorableObject::StorableObjectContainer
       })
     end
 
@@ -152,7 +152,7 @@ class Session
       string: String,
       float: Float64,
       bool: Bool,
-      object: Session::StorableObject::StorableObjects,
+      object: Session::StorableObject::StorableObjectContainer,
     })
   end
 end

--- a/src/kemal-session/storable_object.cr
+++ b/src/kemal-session/storable_object.cr
@@ -19,8 +19,61 @@ class Session
     macro finished
       {% if !Session::STORABLE_TYPES.empty? %}
         alias StorableObjects = Union({{ *Session::STORABLE_TYPES }})
+
+        # This is a container object that allows us to define the type from
+        # session storage so that we can parse everythin correctly
+        #
+        class StorableObjectContainer
+          property type : String
+          property object : Session::StorableObject::StorableObjects
+
+          def initialize(obj : StorableObjects)
+            @type = obj.class.to_s
+            @object = obj
+          end
+
+          def initialize(parser : JSON::PullParser)
+            c = self.class.from_json(parser)
+            @type = c.type
+            @object = c.object
+          end
+
+          def to_json(builder : JSON::Builder)
+            builder.object do
+              builder.field "type", @type
+              builder.field "object" do
+                @object.to_json(builder)
+              end
+            end
+          end
+
+          def self.from_json(parser : JSON::PullParser)
+            # Parse the stuffs. Note that we're not going to parse the
+            # object json for the storable object we need to know the
+            # type before we do so
+            #
+            parser.read_begin_object
+            key  = parser.read_object_key
+            type = parser.read_string
+            parser.read_object_key
+            json = parser.read_raw
+            parser.read_end_object
+
+            {% for type in Session::STORABLE_TYPES %}
+              if "{{ type }}" == type
+                object = {{ type }}.from_json(json)
+              end
+            {% end %}
+
+            if object.nil?
+              raise JSON::ParseException.new("Couldn't parse StorableObject #{type} from #{json}", 0, 0)
+            end
+            return Session::StorableObject::StorableObjectContainer.new(object)
+          end
+        end
       {% else %}
         alias StorableObjects = Nil
+        alias StorableObjectContainer = Nil
       {% end %}
     end
   end


### PR DESCRIPTION
The container allows `kemal-session` to deserialize the object correctly from session storage. The problem arose from how crystal union types deserialize json. The [code](https://github.com/crystal-lang/crystal/blob/3c6c75e68f326bb91be35f71ae30672fd454776e/src/json/from_json.cr#L218-L225) goes through each of the types it aliases and picks the first one that does error. When different StorableObjects look the same in terms of their properties, crystal will deserialize the first one it gets which may or may not be correct.  

For this solution, storage engines don't need to know about the container object other than they need to save the type. Since serialization and deserialization of the container is happening within `kemal-session` engines should be ok. Redis is the only engine that needs updating at this point. If we get this fix in, I can get that one update. 

Fixes #37 and paves the way for getting #41 in as well. I think once we fix these and #39, we'll be in a place to get `kemal-session` ready for production.