### PR TITLE
add a clear method

### DIFF
--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -1,5 +1,11 @@
 require "./spec_helper"
 
+# Config Options
+#
+Session.config.engine = Session::MemoryEngine.new
+Session.config.secret = "kemal_rocks"
+SIGNED_SESSION = "#{SESSION_ID}--#{Session.sign_value(SESSION_ID)}"
+
 describe "Session" do
   describe ".start" do
     it "returns a Session instance" do
@@ -116,8 +122,8 @@ describe "Session" do
     it "will be deserialized in memory engine" do
       session = Session.new(create_context(SESSION_ID))
       session.object("obj", UserTestDeserialization.new(1_i64))
-      s = Session.get(SESSION_ID)
       expect_raises Exception, "calling from_json" do
+        s = Session.get(SESSION_ID)
         s.as(Session).object("obj")
       end
     end

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -160,7 +160,7 @@ describe "Session" do
       session = Session.new(context)
       session.int("user_id", 123)
       current_cookie = context.response.cookies[Session.config.cookie_name].value
-      session.clear
+      session.reset
       new_cookie = context.response.cookies[Session.config.cookie_name].value
       new_cookie.should_not      eq(current_cookie)
       new_cookie.size.should_not eq(0)

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -148,6 +148,23 @@ describe "Session" do
     end
   end
 
+  describe ".clear" do
+    it "should delete the current session from session storage and the cookie value should be different" do
+      context = create_context(SESSION_ID)
+      session = Session.new(context)
+      session.int("user_id", 123)
+      current_cookie = context.response.cookies[Session.config.cookie_name].value
+      session.clear
+      new_cookie = context.response.cookies[Session.config.cookie_name].value
+      new_cookie.should_not      eq(current_cookie)
+      new_cookie.size.should_not eq(0)
+      Session.get(SESSION_ID).should be_nil
+      session.int("user_id", 456)
+      session = Session.get(session.id)
+      session.should_not be_nil
+    end
+  end
+
   describe ".destroy" do
     it "should delete a session and remove cookie in current session" do
       context = create_context(SESSION_ID)

--- a/spec/file_spec.cr
+++ b/spec/file_spec.cr
@@ -8,12 +8,14 @@ Session.config.secret = "super-awesome-secret"
 Session.config.engine = Session::FileEngine.new({:sessions_dir => "./spec/assets/sessions/"})
 
 Spec.before_each do
-  sessions_path = File.join(Dir.current, "spec", "assets", "sessions")
-  Dir.foreach(sessions_path) do |file|
-    next if file == "." || file == ".."
-    File.delete File.join(Dir.current, "spec", "assets", "sessions", file)
+  if Session.config.engine.class == Session::FileEngine
+    sessions_path = File.join(Dir.current, "spec", "assets", "sessions")
+    Dir.foreach(sessions_path) do |file|
+      next if file == "." || file == ".."
+      File.delete File.join(Dir.current, "spec", "assets", "sessions", file)
+    end
+    Session.config.engine.as(Session::FileEngine).clear_cache
   end
-  Session.config.engine.as(Session::FileEngine).clear_cache
 end
 
 def get_file_session_contents(session_id)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,16 +3,7 @@ require "json"
 require "../src/kemal-session"
 require "file_utils"
 
-# Config Options
-#
-Session.config.engine = Session::MemoryEngine.new
-Session.config.secret = "kemal_rocks"
-
-# For testing cookie signing and for having a valid session
-#
-SESSION_SECRET = "b3c631c314c0bbca50c1b2843150fe33"
-SESSION_ID     = SecureRandom.hex
-SIGNED_SESSION = "#{SESSION_ID}--#{Session.sign_value(SESSION_ID)}"
+SESSION_ID = SecureRandom.hex
 
 def create_new_session
   create_context(SecureRandom.hex)

--- a/src/kemal-session/base.cr
+++ b/src/kemal-session/base.cr
@@ -48,13 +48,13 @@ class Session
     @context = nil
   end
 
-  # Clearing the session will remove the contents of the current session
+  # Resetting the session will remove the contents of the current session
   # from session storage and create a new session for use within the
   # current request. The `.destroy` method will remove the session from
   # session storage and not create a new session for use within the current
   # request
   #
-  def clear
+  def reset
     destroy
     if context = @context
       @id = SecureRandom.hex


### PR DESCRIPTION
Will destroy the current session in session storage and then creates a new session id and storage for the current response cycle.