### PR TITLE
Default engine is already set on Config#initialize

### DIFF
--- a/src/kemal-session/base.cr
+++ b/src/kemal-session/base.cr
@@ -10,7 +10,6 @@ class Session
   @context : HTTP::Server::Context?
 
   def initialize(ctx : HTTP::Server::Context)
-    Session.config.set_default_engine unless Session.config.engine_set?
     id = ctx.request.cookies[Session.config.cookie_name]?.try &.value
     valid = false
     if id
@@ -28,7 +27,7 @@ class Session
     end
 
     ctx.response.cookies << Session.create_cookie(id)
-    @id      = id
+    @id = id
     @context = ctx
   end
 
@@ -38,7 +37,7 @@ class Session
   # check on the session_id
   #
   def initialize(id : String)
-    @id      = id
+    @id = id
     @context = nil
   end
 

--- a/src/kemal-session/config.cr
+++ b/src/kemal-session/config.cr
@@ -9,18 +9,11 @@ class Session
     @secret : String
     @secure : Bool
     @domain : String?
-    @path   : String
+    @path : String
     property timeout, gc_interval, cookie_name, engine, secret, secure, domain, path
-
-    @engine_set = false
-
-    def engine_set?
-      @engine_set
-    end
 
     def engine=(e : Engine)
       @engine = e
-      @engine_set = true
     end
 
     def initialize
@@ -31,11 +24,7 @@ class Session
       @secret = ""
       @secure = false
       @domain = nil
-      @path   = "/"
-    end
-
-    def set_default_engine
-      Session.config.engine = MemoryEngine.new
+      @path = "/"
     end
   end # Config
 


### PR DESCRIPTION
There is no need to have `set_default_engine` or `engine_set` flag since the default is already set on the `Config#initialize`.

I ran into this issue when trying to create a spec for a kemal app, in which I had to add to some values to the current session:

```crystal
it "/submit" do
  user = create_user

  session_id = SecureRandom.hex

  # Store the user id in the session.
  # It is required to call `set_default_engine`, otherwise the first
  # request will override it:
  # Session.config.set_default_engine
  sess = Session.config.engine.create_session(session_id)
  sess = Session.get(session_id).not_nil!
  sess.string("user_uuid", user.uuid)

  cookies = HTTP::Cookies.new
  cookies << Session.create_cookie(session_id)
  headers = cookies.add_request_headers(HTTP::Headers.new)

  # Without `set_default_engine`, the first request would
  # override the engine on Session#initialize
  post("/submit", headers: headers)
  response.status_code.should eq 302
end
```

If I didn't call `Session.config.set_default_engine` in the before setting the session, the first request would override it.