### PR TITLE
Add /spec/assets/sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,9 @@
 /.crystal/
 /.shards/
 /spec/assets
-/spec/assets/sessions/
+!/spec/assets/sessions/
 
 
 # Libraries don't need dependency lock
 # Dependencies will be locked in application that uses them
 /shard.lock
-


### PR DESCRIPTION
Now, this project's build status is failing because ```/spec/assets/sessions``` does not exists.
This pull request add the directory and the build status will be green.