### PR TITLE
Add the SameSite config option to the cookie creation

### DIFF
--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -274,6 +274,20 @@ describe "Session" do
     end
   end
 
+  describe "cookie" do
+    it "should create a cookie with the samesite set to strict" do
+       Kemal::Session.config do |config|
+        config.cookie_name = "woops"
+        config.samesite = HTTP::Cookie::SameSite::Strict
+      end
+
+      context = create_cookie_context(SESSION_ID, Kemal::Session.config)
+      session = Kemal::Session.new(context)
+      cookie = context.response.cookies[Kemal::Session.config.cookie_name]
+      cookie.samesite.should eq(HTTP::Cookie::SameSite::Strict)
+    end
+  end
+
   describe "signed cookies" do
     it "should use the same session_id" do
       context = create_context(SESSION_ID)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -27,6 +27,18 @@ def create_context(session_id : String)
   return HTTP::Server::Context.new(request, response)
 end
 
+def create_cookie_context(session_id : String, session)
+  response = HTTP::Server::Response.new(IO::Memory.new)
+  headers = HTTP::Headers.new
+
+  session.engine.create_session(session_id)
+  cookies = HTTP::Cookies.new
+  cookies << HTTP::Cookie.new(Kemal::Session.config.cookie_name, Kemal::Session.encode(session_id))
+  cookies.add_request_headers(headers)
+  request = HTTP::Request.new("GET", "/", headers)
+  return HTTP::Server::Context.new(request, response)
+end
+
 macro expect_not_raises(file = __FILE__, line = __LINE__)
   %failed = false
   begin

--- a/src/kemal-session/base.cr
+++ b/src/kemal-session/base.cr
@@ -130,6 +130,7 @@ module Kemal
         secure: Session.config.secure,
         path: Session.config.path,
         domain: Session.config.domain,
+        samesite: Session.config.samesite
       )
     end
 

--- a/src/kemal-session/config.cr
+++ b/src/kemal-session/config.cr
@@ -11,7 +11,8 @@ module Kemal
       @secure : Bool
       @domain : String?
       @path : String
-      property timeout, gc_interval, cookie_name, engine, secret, secure, domain, path
+      @samesite : Cookie::SameSite?
+      property timeout, gc_interval, cookie_name, engine, secret, secure, domain, path, samesite
 
       def engine=(e : Engine)
         @engine = e
@@ -26,6 +27,7 @@ module Kemal
         @secure = false
         @domain = nil
         @path = "/"
+        @samesite = nil
       end
     end # Config
 
@@ -37,4 +39,5 @@ module Kemal
       Config::INSTANCE
     end
   end # Session
+  include HTTP
 end


### PR DESCRIPTION
I needed to secure the cookie with the SameSite configuration option. This PR adds it.

example:

```crystal
   Kemal::Session.config do |config|
          config.samesite = HTTP::Cookie::SameSite::Strict
      end
```
The value is either SameSite::Strict or SameSite::Lax as per the existing HTTP::Cookie code in Crystal - if it's left unconfigured then it defaults to nil in the same way domain works