### PR TITLE
Crystal 0.33.0

### DIFF
--- a/spec/file_spec.cr
+++ b/spec/file_spec.cr
@@ -1,11 +1,10 @@
 require "./spec_helper"
 require "file_utils"
-require "tempfile"
 require "random/secure"
 
 # Set the folder to use for all of these tests
 #
-SESSION_DIR = File.join(Tempfile.dirname, Random::Secure.hex) + "/"
+SESSION_DIR = File.join(Dir.tempdir, Random::Secure.hex) + "/"
 Dir.mkdir(SESSION_DIR)
 
 # Set the engine for all of these tests

--- a/src/kemal-session/base.cr
+++ b/src/kemal-session/base.cr
@@ -14,7 +14,7 @@ module Kemal
       id = ctx.request.cookies[Session.config.cookie_name]?.try &.value
       valid = false
       if id
-        parts = URI.unescape(id).split("--")
+        parts = URI.decode(id).split("--")
         if parts.size == 2
           new_val = self.class.sign_value(parts[0])
           id = parts[0]
@@ -125,7 +125,7 @@ module Kemal
       HTTP::Cookie.new(
         name: Session.config.cookie_name,
         value: self.encode(session_id),
-        expires: Time.now.to_utc + Session.config.timeout,
+        expires: Time.utc + Session.config.timeout,
         http_only: true,
         secure: Session.config.secure,
         path: Session.config.path,

--- a/src/kemal-session/engines/file.cr
+++ b/src/kemal-session/engines/file.cr
@@ -62,14 +62,14 @@ module Kemal
         @sessions_dir = uninitialized String
         @sessions_dir = options[:sessions_dir]
         @cache = StorageInstance.new
-        @cached_session_read_time = Time.utc_now
+        @cached_session_read_time = Time.utc
         @cached_session_id = ""
       end
 
       def run_gc
         each_session do |session|
           full_path = session_filename(session.id)
-          age = Time.utc_now - File.info(full_path).modification_time # mtime is always saved in utc
+          age = Time.utc - File.info(full_path).modification_time # mtime is always saved in utc
           session.destroy if age.total_seconds > Session.config.timeout.total_seconds
         end
       end
@@ -85,10 +85,10 @@ module Kemal
       end
 
       def is_in_cache?(session_id : String) : Bool
-        if (@cached_session_read_time.to_unix / 60) < (Time.utc_now.to_unix / 60)
-          @cached_session_read_time = Time.utc_now
+        if (@cached_session_read_time.to_unix / 60) < (Time.utc.to_unix / 60)
+          @cached_session_read_time = Time.utc
           begin
-            File.utime(Time.now, Time.now, session_filename(session_id))
+            File.utime(Time.utc, Time.utc, session_filename(session_id))
           rescue ex
             puts "Kemal-session cannot update time of a sesssion file. This may not be possible on your current file system"
           end
@@ -110,7 +110,7 @@ module Kemal
           end
         end
         instance = StorageInstance.new
-        @cached_session_read_time = Time.utc_now
+        @cached_session_read_time = Time.utc
         File.write(session_filename(session_id), instance.to_json)
         return instance
       end
@@ -123,7 +123,7 @@ module Kemal
         read_or_create_storage_instance(session_id)
       end
 
-      def get_session(session_id : String)
+      def get_session(session_id : String) : Kemal::Session?
         return Session.new(session_id) if session_exists?(session_id)
         nil
       end
@@ -140,7 +140,7 @@ module Kemal
         end
       end
 
-      def all_sessions
+      def all_sessions : Array(Kemal::Session)
         array = [] of Session
 
         each_session do |session|
@@ -151,6 +151,7 @@ module Kemal
       end
 
       def each_session
+        return false unless Dir.exists?(@sessions_dir)
         Dir.each_child(@sessions_dir) do |f|
           full_path = File.join(@sessions_dir, f)
           if session_file?(f)

--- a/src/kemal-session/engines/file.cr
+++ b/src/kemal-session/engines/file.cr
@@ -85,7 +85,7 @@ module Kemal
       end
 
       def is_in_cache?(session_id : String) : Bool
-        if (@cached_session_read_time.epoch / 60) < (Time.utc_now.epoch / 60)
+        if (@cached_session_read_time.to_unix / 60) < (Time.utc_now.to_unix / 60)
           @cached_session_read_time = Time.utc_now
           begin
             File.utime(Time.now, Time.now, session_filename(session_id))

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -18,26 +18,26 @@ module Kemal
 
         {% for name, type in vars %}
           @{{name.id}}s = Hash(String, {{type}}).new
-          @last_access_at = Time.new.epoch_ms
+          @last_access_at = Time.new.to_unix_ms
           getter {{name.id}}s
 
           def {{name.id}}(k : String) : {{type}}
-            @last_access_at = Time.new.epoch_ms
+            @last_access_at = Time.new.to_unix_ms
             return @{{name.id}}s[k]
           end
 
           def {{name.id}}?(k : String) : {{type}}?
-            @last_access_at = Time.new.epoch_ms
+            @last_access_at = Time.new.to_unix_ms
             return @{{name.id}}s[k]?
           end
 
           def {{name.id}}(k : String, v : {{type}})
-            @last_access_at = Time.new.epoch_ms
+            @last_access_at = Time.new.to_unix_ms
             @{{name.id}}s[k] = v
           end
 
           def delete_{{name.id}}(k : String)
-            @last_access_at = Time.new.epoch_ms
+            @last_access_at = Time.new.to_unix_ms
             @{{name.id}}s.delete(k) if @{{name.id}}s.has_key?(k)
           end
         {% end %}
@@ -66,7 +66,7 @@ module Kemal
       end
 
       def run_gc
-        before = (Time.now - Kemal::Session.config.timeout.as(Time::Span)).epoch_ms
+        before = (Time.now - Kemal::Session.config.timeout.as(Time::Span)).to_unix_ms
         @store.delete_if do |id, entry|
           last_access_at = Int64.from_json(entry, root: "last_access_at")
           last_access_at < before

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -18,26 +18,26 @@ module Kemal
 
         {% for name, type in vars %}
           @{{name.id}}s = Hash(String, {{type}}).new
-          @last_access_at = Time.new.to_unix_ms
+          @last_access_at = Time.utc.to_unix_ms
           getter {{name.id}}s
 
           def {{name.id}}(k : String) : {{type}}
-            @last_access_at = Time.new.to_unix_ms
+            @last_access_at = Time.utc.to_unix_ms
             return @{{name.id}}s[k]
           end
 
           def {{name.id}}?(k : String) : {{type}}?
-            @last_access_at = Time.new.to_unix_ms
+            @last_access_at = Time.utc.to_unix_ms
             return @{{name.id}}s[k]?
           end
 
           def {{name.id}}(k : String, v : {{type}})
-            @last_access_at = Time.new.to_unix_ms
+            @last_access_at = Time.utc.to_unix_ms
             @{{name.id}}s[k] = v
           end
 
           def delete_{{name.id}}(k : String)
-            @last_access_at = Time.new.to_unix_ms
+            @last_access_at = Time.utc.to_unix_ms
             @{{name.id}}s.delete(k) if @{{name.id}}s.has_key?(k)
           end
         {% end %}
@@ -50,11 +50,11 @@ module Kemal
       end
 
         define_storage({
-          int: Int32,
+          int:    Int32,
           bigint: Int64,
-          string:  String,
-          float:   Float64,
-          bool: Bool,
+          string: String,
+          float:  Float64,
+          bool:   Bool,
           object: Kemal::Session::StorableObject::StorableObjectContainer,
         })
       end
@@ -66,7 +66,7 @@ module Kemal
       end
 
       def run_gc
-        before = (Time.now - Kemal::Session.config.timeout.as(Time::Span)).to_unix_ms
+        before = (Time.utc - Kemal::Session.config.timeout.as(Time::Span)).to_unix_ms
         @store.delete_if do |id, entry|
           last_access_at = Int64.from_json(entry, root: "last_access_at")
           last_access_at < before
@@ -74,7 +74,7 @@ module Kemal
         sleep Kemal::Session.config.gc_interval
       end
 
-      def all_sessions
+      def all_sessions : Array(Kemal::Session)
         @store.each_with_object([] of Session) do |vals, arr|
           arr << Kemal::Session.new(vals.first)
         end
@@ -90,7 +90,7 @@ module Kemal
         end
       end
 
-      def get_session(session_id : String)
+      def get_session(session_id : String) : Kemal::Session?
         return nil if !@store.has_key?(session_id)
         Session.new(session_id)
       end
@@ -148,11 +148,11 @@ module Kemal
     end
 
       define_delegators({
-        int: Int32,
+        int:    Int32,
         bigint: Int64,
-        string:  String,
-        float:   Float64,
-        bool: Bool,
+        string: String,
+        float:  Float64,
+        bool:   Bool,
         object: Session::StorableObject::StorableObjectContainer,
       })
     end


### PR DESCRIPTION
Removes deprecated Time.now and Time.new, I used .utc instead.
Also fixed warnings about some abstract methods having explicit return types, while their overriding methods didn't.