### PR TITLE
Fixes #91 a compiler error on 0.36 due to JSON.mapping

### DIFF
--- a/src/kemal-session/engines/file.cr
+++ b/src/kemal-session/engines/file.cr
@@ -4,13 +4,8 @@ module Kemal
   class Session
     class FileEngine < Engine
       class StorageInstance
+        include JSON::Serializable
         macro define_storage(vars)
-          JSON.mapping({
-            {% for name, type in vars %}
-              {{name.id}}s: Hash(String, {{type}}),
-            {% end %}
-          })
-
           {% for name, type in vars %}
             @{{name.id}}s = Hash(String, {{type}}).new
             getter {{name.id}}s

--- a/src/kemal-session/engines/memory.cr
+++ b/src/kemal-session/engines/memory.cr
@@ -4,17 +4,10 @@ module Kemal
   class Session
     class MemoryEngine < Engine
       class StorageInstance
+        include JSON::Serializable
         macro define_storage(vars)
         getter! id : String
         property! last_access_at : Int64
-
-        JSON.mapping({
-          {% for name, type in vars %}
-            {{name.id}}s: Hash(String, {{type}}),
-          {% end %}
-          last_access_at: Int64,
-          id: String,
-        })
 
         {% for name, type in vars %}
           @{{name.id}}s = Hash(String, {{type}}).new


### PR DESCRIPTION
Fixes #91 This is a minor change to fix 0.36 compiler error by changing JSON.mapping into JSON::Serializable.  