### PR TITLE
Avoid one array allocation removing an instance variable.

### DIFF
--- a/src/kemal-session/csrf.cr
+++ b/src/kemal-session/csrf.cr
@@ -13,16 +13,16 @@ module Kemal
         @allowed_methods = %w(GET HEAD OPTIONS TRACE),
         @parameter_name = "authenticity_token",
         @error : String | (HTTP::Server::Context -> String) = "Forbidden (CSRF)",
-        @allowed_routes = [] of String,
+        allowed_routes : Array(String)? = nil,
         @http_only : Bool = false,
         @samesite : HTTP::Cookie::SameSite? = nil,
         @per_session : Bool = false,
       )
-        setup
+        setup(allowed_routes) if allowed_routes
       end
 
-      def setup
-        @allowed_routes.each do |path|
+      private def setup(allowed_routes : Array(String))
+        allowed_routes.each do |path|
           class_name = {{@type.name}}
           %w(GET HEAD OPTIONS TRACE PUT POST).each do |method|
             @@exclude_routes_tree.add "#{class_name}/#{method}#{path}", "/#{method}#{path}"


### PR DESCRIPTION
I know that _early optimization is the root of all evil_, but this change doesn't hurt and IMO nether added complexity to the code.
