### PR TITLE
Set default SameSite cookie policy to Lax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.5.0 (11-04-2026)
+
+- Default session cookie `SameSite` to `Lax` (previously unset). Improves protection against cross-site cookie sending while keeping typical first-visit flows working; use `config.samesite = nil` to omit the attribute, or `HTTP::Cookie::SameSite::Strict` for a stricter policy.
+
 # 1.4.0 (03-02-2026)
 
 - Prevent empty sessions from being stored (lazy session creation) [#113](https://github.com/kemalcr/kemal-session/pull/113) Thanks @sdogruyol :pray:

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Kemal::Session.config.timeout = 30.minutes
 | `secure` | Send cookie only over HTTPS | `false` | `true` for production |
 | `domain` | Scope cookie to specific domain | `nil` | `"example.com"` |
 | `path` | Scope cookie to specific path | `"/"` | `"/app"` |
-| `samesite` | SameSite cookie policy | `nil` | `HTTP::Cookie::SameSite::Strict` |
+| `samesite` | SameSite cookie policy | `HTTP::Cookie::SameSite::Lax` | `HTTP::Cookie::SameSite::Strict` |
 
 ### 🔐 Security Best Practices
 

--- a/spec/base_spec.cr
+++ b/spec/base_spec.cr
@@ -276,6 +276,11 @@ describe "Session" do
   end
 
   describe "cookie" do
+    it "defaults samesite to Lax for new Config" do
+      cfg = Kemal::Session::Config.new
+      cfg.samesite.should eq(HTTP::Cookie::SameSite::Lax)
+    end
+
     it "should create a cookie with the samesite set to strict" do
       Kemal::Session.config do |config|
         config.cookie_name = "woops"

--- a/src/kemal-session/config.cr
+++ b/src/kemal-session/config.cr
@@ -27,7 +27,7 @@ module Kemal
         @secure = false
         @domain = nil
         @path = "/"
-        @samesite = nil
+        @samesite = Cookie::SameSite::Lax
       end
     end # Config
 
@@ -39,5 +39,6 @@ module Kemal
       Config::INSTANCE
     end
   end # Session
+
   include HTTP
 end


### PR DESCRIPTION
## Summary

Sets the session cookie **SameSite** default to **`Lax`** instead of leaving it unset (`nil`).

## Motivation

- Reduces risk of the session cookie being sent on cross-site requests (CSRF-style chains), in line with common security guidance (“at least Lax”).
- Aligns with defaults or explicit choices in much of the ecosystem (e.g. Flask, Gorilla sessions, Fiber’s direction), while avoiding **Strict** as the default so first visits from external links (email, search) still behave predictably.

## Behavior

| Before | After |
|--------|--------|
| `samesite` default `nil` (attribute omitted; browser-dependent) | `HTTP::Cookie::SameSite::Lax` |

Apps that need the old behavior can use:

```crystal
Kemal::Session.config.samesite = nil